### PR TITLE
OSOE-49: Enforce Windows newlines for C# files to avoid false positives with IDE0055 warning.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 * text=auto
 
-# Enforce Windows newlines for C# files to avoid false positives with IDE55 warning.
+# Enforce Windows newlines for C# files to avoid false positives with IDE0055 warning.
 *.cs text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 * text=auto
 
 # Enforce Windows newlines for C# files to avoid false positives with IDE0055 warning.
-# See https://github.com/Lombiq/Open-Source-Orchard-Core-Extensions/issues/106
+# See https://github.com/Lombiq/Open-Source-Orchard-Core-Extensions/issues/106 for more information.
 *.cs text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text=auto
 
 # Enforce Windows newlines for C# files to avoid false positives with IDE0055 warning.
+# See https://github.com/Lombiq/Open-Source-Orchard-Core-Extensions/issues/106
 *.cs text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 * text=auto
+
+# Enforce Windows newlines for C# files to avoid false positives with IDE55 warning.
+*.cs text eol=crlf


### PR DESCRIPTION
OSOE-49