### PR TITLE
LMBQ-175: Fixing standalone `,` if headerValue is empty

### DIFF
--- a/Lombiq.Hosting.Tenants.EnvironmentRobots/Middlewares/EnvironmentRobotsMiddleware.cs
+++ b/Lombiq.Hosting.Tenants.EnvironmentRobots/Middlewares/EnvironmentRobotsMiddleware.cs
@@ -31,7 +31,12 @@ public class EnvironmentRobotsMiddleware
         {
             var headerValue = context.Response.Headers["X-Robots-Tag"].FirstOrDefault() ?? string.Empty;
 
-            var directives = new List<string> { headerValue };
+            var directives = new List<string>();
+
+            if (!string.IsNullOrEmpty(headerValue))
+            {
+                directives.Add(headerValue);
+            }
 
             if (!headerValue.Contains("noindex"))
             {

--- a/Lombiq.Hosting.Tenants.EnvironmentRobots/Middlewares/EnvironmentRobotsMiddleware.cs
+++ b/Lombiq.Hosting.Tenants.EnvironmentRobots/Middlewares/EnvironmentRobotsMiddleware.cs
@@ -38,10 +38,13 @@ public class EnvironmentRobotsMiddleware
                 directives.Add(headerValue);
             }
 
+            // False warning, since headerValue is initialized to string.Empty if it would be null.
+#pragma warning disable S2259 // Null pointers should not be dereferenced
             if (!headerValue.Contains("noindex"))
             {
                 directives.Add("noindex");
             }
+#pragma warning restore S2259 // Null pointers should not be dereferenced
 
             if (!headerValue.Contains("nofollow"))
             {


### PR DESCRIPTION
[LMBQ-175](https://lombiq.atlassian.net/browse/LMBQ-175)

[LMBQ-175]: https://lombiq.atlassian.net/browse/LMBQ-175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ