### PR TITLE
OSOE-697: Standardize feature names with the non-hyphenated "Lombiq Hosting - Tenants" prefix in Lombiq.Hosting.Tenants

### DIFF
--- a/Lombiq.Hosting.Tenants.Admin.Login/Manifest.cs
+++ b/Lombiq.Hosting.Tenants.Admin.Login/Manifest.cs
@@ -19,7 +19,7 @@ using static Lombiq.Hosting.Tenants.Admin.Login.Constants.FeatureNames;
 
 [assembly: Feature(
     Id = SubTenant,
-    Name = "Lombiq Hosting - Tenants Admin Login - Sub-tenant",
+    Name = "Lombiq Hosting - Tenants Admin Login Sub-tenant",
     Description = "Adds the ability to log in to the tenant from the Default tenant.",
     Category = "Hosting",
     IsAlwaysEnabled = true

--- a/Lombiq.Hosting.Tenants.EmailQuotaManagement/Manifest.cs
+++ b/Lombiq.Hosting.Tenants.EmailQuotaManagement/Manifest.cs
@@ -2,7 +2,7 @@ using Lombiq.Hosting.Tenants.EmailQuotaManagement.Constants;
 using OrchardCore.Modules.Manifest;
 
 [assembly: Module(
-    Name = "Lombiq Hosting - Tenants - Email Quota Management",
+    Name = "Lombiq Hosting - Tenants Email Quota Management",
     Author = "Lombiq Technologies",
     Website = "https://github.com/Lombiq/Hosting-Tenants",
     Version = "0.0.1",
@@ -12,7 +12,7 @@ using OrchardCore.Modules.Manifest;
 
 [assembly: Feature(
     Id = FeatureNames.EmailQuotaManagement,
-    Name = "Lombiq Hosting - Tenants - Email Quota Management",
+    Name = "Lombiq Hosting - Tenants Email Quota Management",
     Category = "Hosting",
     IsAlwaysEnabled = true,
     Dependencies = new[]

--- a/Lombiq.Hosting.Tenants.EnvironmentRobots/Manifest.cs
+++ b/Lombiq.Hosting.Tenants.EnvironmentRobots/Manifest.cs
@@ -2,7 +2,7 @@ using Lombiq.Hosting.Tenants.EnvironmentRobots.Constants;
 using OrchardCore.Modules.Manifest;
 
 [assembly: Module(
-    Name = "Lombiq Hosting - Tenants - Environment Robots",
+    Name = "Lombiq Hosting - Tenants Environment Robots",
     Author = "Lombiq Technologies",
     Website = "https://github.com/Lombiq/Hosting-Tenants",
     Version = "0.0.1",
@@ -13,7 +13,7 @@ using OrchardCore.Modules.Manifest;
 
 [assembly: Feature(
     Id = FeatureNames.EnvironmentRobots,
-    Name = "Lombiq Hosting - Tenants - Environment Robots",
+    Name = "Lombiq Hosting - Tenants Environment Robots",
     Category = "Hosting",
     IsAlwaysEnabled = true
 )]

--- a/Lombiq.Hosting.Tenants.FeaturesGuard/Manifest.cs
+++ b/Lombiq.Hosting.Tenants.FeaturesGuard/Manifest.cs
@@ -2,7 +2,7 @@ using Lombiq.Hosting.Tenants.FeaturesGuard.Constants;
 using OrchardCore.Modules.Manifest;
 
 [assembly: Module(
-    Name = "Lombiq Hosting - Tenants - Features Guard",
+    Name = "Lombiq Hosting - Tenants Features Guard",
     Author = "Lombiq Technologies",
     Website = "https://github.com/Lombiq/Hosting-Tenants",
     Version = "0.0.1",
@@ -12,7 +12,7 @@ using OrchardCore.Modules.Manifest;
 
 [assembly: Feature(
     Id = FeatureNames.FeaturesGuard,
-    Name = "Lombiq Hosting - Tenants - Features Guard",
+    Name = "Lombiq Hosting - Tenants Features Guard",
     Category = "Hosting",
     IsAlwaysEnabled = true
 )]

--- a/Lombiq.Hosting.Tenants.IdleTenantManagement/Manifest.cs
+++ b/Lombiq.Hosting.Tenants.IdleTenantManagement/Manifest.cs
@@ -2,7 +2,7 @@ using OrchardCore.Modules.Manifest;
 using static Lombiq.Hosting.Tenants.IdleTenantManagement.Constants.FeatureNames;
 
 [assembly: Module(
-    Name = "Lombiq Hosting - Idle Tenant Management",
+    Name = "Lombiq Hosting - Tenants Idle Tenant Management",
     Author = "Lombiq Technologies",
     Website = "https://github.com/Lombiq/Hosting-Tenants",
     Version = "0.0.1",
@@ -11,7 +11,7 @@ using static Lombiq.Hosting.Tenants.IdleTenantManagement.Constants.FeatureNames;
 
 [assembly: Feature(
     Id = ShutDownIdleTenants,
-    Name = "Lombiq Hosting - Idle Tenant Management - Shut Down Idle Tenants",
+    Name = "Lombiq Hosting - Tenants Idle Tenant Management Shut Down Idle Tenants",
     Description = "Shut down tenants not receiving requests after a configured amount of time to conserve computing resources.",
     Category = "Hosting",
     Priority = "9999",

--- a/Lombiq.Hosting.Tenants.Maintenance/Manifest.cs
+++ b/Lombiq.Hosting.Tenants.Maintenance/Manifest.cs
@@ -18,7 +18,7 @@ using static Lombiq.Hosting.Tenants.Maintenance.Constants.FeatureNames;
 
 [assembly: Feature(
     Id = UpdateSiteUrl,
-    Name = "Lombiq Hosting - Tenants Maintenance - Update Site URL",
+    Name = "Lombiq Hosting - Tenants Maintenance Update Site URL",
     Description = "Updates the URL of the site in the site settings (e.g., when the production database is copied to staging).",
     Category = "Maintenance",
     Dependencies = new[] { Maintenance }
@@ -26,7 +26,7 @@ using static Lombiq.Hosting.Tenants.Maintenance.Constants.FeatureNames;
 
 [assembly: Feature(
     Id = UpdateShellRequestUrls,
-    Name = "Lombiq Hosting - Tenants Maintenance - Update Shell Request URLs",
+    Name = "Lombiq Hosting - Tenants Maintenance Update Shell Request URLs",
     Description = "Updates the shell request URLs of each tenant (e.g., when the production database is copied to staging)." +
         " It's executed only on the default tenant.",
     Category = "Maintenance",
@@ -36,7 +36,7 @@ using static Lombiq.Hosting.Tenants.Maintenance.Constants.FeatureNames;
 
 [assembly: Feature(
     Id = AddSiteOwnerPermissionToRole,
-    Name = "Lombiq Hosting - Tenants Maintenance - Add Site Owner Permission To Role",
+    Name = "Lombiq Hosting - Tenants Maintenance Add Site Owner Permission To Role",
     Description = "Adds the Site Owner permission to a role (e.g., when the production database is copied to staging).",
     Category = "Maintenance",
     DefaultTenantOnly = true,
@@ -45,7 +45,7 @@ using static Lombiq.Hosting.Tenants.Maintenance.Constants.FeatureNames;
 
 [assembly: Feature(
     Id = RemoveUsers,
-    Name = "Lombiq Hosting - Tenants Maintenance - Remove Users",
+    Name = "Lombiq Hosting - Tenants Maintenance Remove Users",
     Description = "Removes users with the configured email domain.",
     Category = "Maintenance",
     DefaultTenantOnly = true,
@@ -54,7 +54,7 @@ using static Lombiq.Hosting.Tenants.Maintenance.Constants.FeatureNames;
 
 [assembly: Feature(
     Id = ChangeUserSensitiveContent,
-    Name = "Lombiq Hosting - Tenants Maintenance - Change User Sensitive Content",
+    Name = "Lombiq Hosting - Tenants Maintenance Change User Sensitive Content",
     Description = "Replaces the users' username, email and password with realistic but random values.",
     Category = "Maintenance",
     DefaultTenantOnly = true,

--- a/Lombiq.Hosting.Tenants.Management/Manifest.cs
+++ b/Lombiq.Hosting.Tenants.Management/Manifest.cs
@@ -11,7 +11,7 @@ using static Lombiq.Hosting.Tenants.Management.Constants.FeatureNames;
 
 [assembly: Feature(
     Id = ForbiddenTenantNames,
-    Name = "Lombiq Hosting - Tenants Management - Forbidden Tenant Names",
+    Name = "Lombiq Hosting - Tenants Management Forbidden Tenant Names",
     Description = "Ability to configure hostnames that aren't allowed during tenant creation.",
     Category = "Hosting",
     DefaultTenantOnly = true,
@@ -20,7 +20,7 @@ using static Lombiq.Hosting.Tenants.Management.Constants.FeatureNames;
 
 [assembly: Feature(
     Id = HideRecipesFromSetup,
-    Name = "Lombiq Hosting - Tenants Management - Hide Recipes From Setup",
+    Name = "Lombiq Hosting - Tenants Management Hide Recipes From Setup",
     Description = "Adds the ability to hide recipes from the setup screen based on configurable tags.",
     Category = "Hosting",
     DefaultTenantOnly = true,
@@ -29,7 +29,7 @@ using static Lombiq.Hosting.Tenants.Management.Constants.FeatureNames;
 
 [assembly: Feature(
     Id = ShellSettingsEditor,
-    Name = "Lombiq Hosting - Tenants Management - Shell Settings Editor",
+    Name = "Lombiq Hosting - Tenants Management Shell Settings Editor",
     Description = "Adds a shell settings editor to the tenant editor page.",
     Category = "Hosting",
     DefaultTenantOnly = true,

--- a/Lombiq.Hosting.Tenants.MediaStorageManagement/Manifest.cs
+++ b/Lombiq.Hosting.Tenants.MediaStorageManagement/Manifest.cs
@@ -11,7 +11,7 @@ using static Lombiq.Hosting.Tenants.MediaStorageManagement.Constants.FeatureName
 
 [assembly: Feature(
     Id = MediaStorageManagement,
-    Name = "Lombiq Hosting - Tenants Media Storage Management - Quota Management",
+    Name = "Lombiq Hosting - Tenants Media Storage Management Quota Management",
     Description = "Ability to configure storage quota for tenants.",
     Category = "Hosting",
     IsAlwaysEnabled = true,


### PR DESCRIPTION
[OSOE-697](https://lombiq.atlassian.net/browse/OSOE-697)
Fixes #90

[OSOE-697]: https://lombiq.atlassian.net/browse/OSOE-697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ