### PR TITLE
NEST-524: Not increasing MaxRequestBodySize beyond its preconfigured size

### DIFF
--- a/Lombiq.Hosting.Tenants.MediaStorageManagement/Filters/MediaStorageQuotaActionFilter.cs
+++ b/Lombiq.Hosting.Tenants.MediaStorageManagement/Filters/MediaStorageQuotaActionFilter.cs
@@ -26,7 +26,13 @@ public class MediaStorageQuotaActionFilter : IAsyncAuthorizationFilter, IOrdered
         context.HttpContext.Features.Set<IFormFeature>(new FormFeature(context.HttpContext.Request, formOptions));
 
         var maxRequestBodySizeFeature = context.HttpContext.Features.Get<IHttpMaxRequestBodySizeFeature>();
-        if (maxRequestBodySizeFeature is { IsReadOnly: false })
+        // Only setting MaxRequestBodySize if it wouldn't go over the preconfigured size. This is necessary because
+        // larger requests would pose a security issue (since the original limit was configured for a reason), and under
+        // IIS it wouldn't work with the following message anyway: "Increasing the MaxRequestBodySize conflicts with the
+        // max value for IIS limit maxAllowedContentLength. HTTP requests that have a content length greater than
+        // maxAllowedContentLength will still be rejected by IIS. You can disable the limit by either removing or
+        // setting the maxAllowedContentLength value to a higher limit."
+        if (maxRequestBodySizeFeature is { IsReadOnly: false } && maxRequestBodySizeFeature.MaxRequestBodySize > maxFileSize)
         {
             maxRequestBodySizeFeature.MaxRequestBodySize = maxFileSize;
         }


### PR DESCRIPTION
[NEST-524](https://lombiq.atlassian.net/browse/NEST-524)

[NEST-524]: https://lombiq.atlassian.net/browse/NEST-524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ