### PR TITLE
OSOE-848: EmailQuotaService has unnecessary ISession.SaveAsync() calls in Lombiq.Hosting.Tenants

### DIFF
--- a/Lombiq.Hosting.Tenants.EmailQuotaManagement/Services/EmailQuotaService.cs
+++ b/Lombiq.Hosting.Tenants.EmailQuotaManagement/Services/EmailQuotaService.cs
@@ -19,6 +19,8 @@ using static OrchardCore.Security.StandardPermissions;
 
 namespace Lombiq.Hosting.Tenants.EmailQuotaManagement.Services;
 
+// As noted under github issue https://github.com/OrchardCMS/OrchardCore/issues/15290#issuecomment-2093363619
+// SaveAsync calls should be removed due to redundancy, however removing them breaks functionality.
 public class EmailQuotaService : IEmailQuotaService
 {
     private readonly ISession _session;

--- a/Lombiq.Hosting.Tenants.EmailQuotaManagement/Services/EmailQuotaService.cs
+++ b/Lombiq.Hosting.Tenants.EmailQuotaManagement/Services/EmailQuotaService.cs
@@ -19,8 +19,8 @@ using static OrchardCore.Security.StandardPermissions;
 
 namespace Lombiq.Hosting.Tenants.EmailQuotaManagement.Services;
 
-// As noted under github issue https://github.com/OrchardCMS/OrchardCore/issues/15290#issuecomment-2093363619
-// SaveAsync calls should be removed due to redundancy, however removing them breaks functionality.
+// As noted under the GitHub issue https://github.com/OrchardCMS/OrchardCore/issues/15290#issuecomment-2093363619
+// SaveAsync calls could be removed due to redundancy, however, removing them actually breaks functionality.
 public class EmailQuotaService : IEmailQuotaService
 {
     private readonly ISession _session;


### PR DESCRIPTION
[OSOE-848](https://lombiq.atlassian.net/browse/OSOE-848)
Fixes #118

[OSOE-848]: https://lombiq.atlassian.net/browse/OSOE-848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ