### PR TITLE
Adding missing OrchardCore.Search.Elasticsearch dependency to DeleteOrRebuildElasticsearchIndices, and removing unneeded dependency from Lombiq.Hosting.Tenants.EmailQuotaManagement

### DIFF
--- a/Lombiq.Hosting.Tenants.EmailQuotaManagement/Manifest.cs
+++ b/Lombiq.Hosting.Tenants.EmailQuotaManagement/Manifest.cs
@@ -17,7 +17,6 @@ using OrchardCore.Modules.Manifest;
     IsAlwaysEnabled = true,
     Dependencies =
     [
-        "OrchardCore.Emails",
         "Lombiq.HelpfulExtensions.Emails",
     ]
 )]

--- a/Lombiq.Hosting.Tenants.Maintenance/Manifest.cs
+++ b/Lombiq.Hosting.Tenants.Maintenance/Manifest.cs
@@ -67,7 +67,7 @@ using static Lombiq.Hosting.Tenants.Maintenance.Constants.FeatureNames;
     Name = "Lombiq Hosting - Tenants Maintenance Delete Elasticsearch Indexes",
     Description = "Deletes Elasticsearch indexes.",
     Category = "Maintenance",
-    Dependencies = [Maintenance]
+    Dependencies = [Maintenance, "OrchardCore.Search.Elasticsearch"]
 )]
 
 [assembly: Feature(


### PR DESCRIPTION
[OSOE-983](https://lombiq.atlassian.net/browse/OSOE-983)
Fixes #144
Fixes #143

[OSOE-983]: https://lombiq.atlassian.net/browse/OSOE-983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ