### PR TITLE
OSOE-1037: Use `ISession.FlushAsync()` instead of `SaveChangesAsync()` in Lombiq.Hosting.Tenants

### DIFF
--- a/Lombiq.Hosting.Tenants.Maintenance/Services/MaintenanceManager.cs
+++ b/Lombiq.Hosting.Tenants.Maintenance/Services/MaintenanceManager.cs
@@ -115,7 +115,7 @@ public class MaintenanceManager : IMaintenanceManager
             }
 
             await _session.SaveAsync(execution, collection: DocumentCollections.Maintenance);
-            await _session.SaveChangesAsync();
+            await _session.FlushAsync();
 
             if (context.ReloadShellAfterMaintenanceCompletion) await _shellHost.ReloadShellContextAsync(_shellSettings);
         }


### PR DESCRIPTION
[OSOE-1037](https://lombiq.atlassian.net/browse/OSOE-1037)
Fixes #149

[OSOE-1037]: https://lombiq.atlassian.net/browse/OSOE-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ