### PR TITLE
LMBQ-555: Fix MaintenanceManager failure

### DIFF
--- a/Lombiq.Hosting.Tenants.Maintenance/Services/MaintenanceManager.cs
+++ b/Lombiq.Hosting.Tenants.Maintenance/Services/MaintenanceManager.cs
@@ -115,7 +115,7 @@ public class MaintenanceManager : IMaintenanceManager
             }
 
             await _session.SaveAsync(execution, collection: DocumentCollections.Maintenance);
-            await _session.FlushAsync();
+            await _session.SaveChangesAsync();
 
             if (context.ReloadShellAfterMaintenanceCompletion) await _shellHost.ReloadShellContextAsync(_shellSettings);
         }

--- a/Lombiq.Hosting.Tenants.Maintenance/Services/MaintenanceManager.cs
+++ b/Lombiq.Hosting.Tenants.Maintenance/Services/MaintenanceManager.cs
@@ -114,6 +114,8 @@ public class MaintenanceManager : IMaintenanceManager
                     provider.Id);
             }
 
+            // We must use SaveChangesAsync and not FlushAsync, otherwise the migration will fail after site reset. See
+            // https://github.com/Lombiq/Hosting-Tenants/pull/182 for details.
             await _session.SaveAsync(execution, collection: DocumentCollections.Maintenance);
             await _session.SaveChangesAsync();
 


### PR DESCRIPTION
This fixes the error that happens only after launching the `Reset Azure Staging Environment` workflow, [as discussed on Jira](https://lombiq.atlassian.net/browse/[LMBQ-555](https://lombiq.atlassian.net/browse/LMBQ-555)?focusedCommentId=112368).
The application gets stuck in a maintenance failure loop, rendering the site inaccessible with 500 errors and an ever-climbing amount of exceptions on the Application Insights logs.

[LMBQ-555]: https://lombiq.atlassian.net/browse/LMBQ-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ