### PR TITLE
OSOE-1265: Fix MA0193 analyzer warnings

### DIFF
--- a/Lombiq.Hosting.Tenants.EmailQuotaManagement.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.Hosting.Tenants.EmailQuotaManagement.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -46,7 +46,7 @@ public static class TestCaseUITestContextExtensions
 
             if (!quotaShouldBeEnforced) continue;
 
-            var warningLevel = Convert.ToInt32(Math.Round((double)quotaAwareEmailCount / maximumEmailQuota * 100, 0));
+            var warningLevel = Convert.ToInt32(Math.Round((double)quotaAwareEmailCount / maximumEmailQuota * 100, 0, MidpointRounding.AwayFromZero));
             if (warningLevel >= 100)
             {
                 await context.GoToDashboardAsync();

--- a/Lombiq.Hosting.Tenants.EmailQuotaManagement/Models/EmailQuota.cs
+++ b/Lombiq.Hosting.Tenants.EmailQuotaManagement/Models/EmailQuota.cs
@@ -9,5 +9,5 @@ public class EmailQuota
     public int LastReminderPercentage { get; set; }
 
     public int CurrentUsagePercentage(int emailQuotaPerMonth) =>
-        Convert.ToInt32(Math.Round((double)CurrentEmailUsageCount / emailQuotaPerMonth * 100, 0));
+        Convert.ToInt32(Math.Round((double)CurrentEmailUsageCount / emailQuotaPerMonth * 100, 0, MidpointRounding.AwayFromZero));
 }

--- a/Lombiq.Hosting.Tenants.Maintenance/Models/StaggeredTenantWakeUpPart.cs
+++ b/Lombiq.Hosting.Tenants.Maintenance/Models/StaggeredTenantWakeUpPart.cs
@@ -23,7 +23,7 @@ public class StaggeredTenantWakeUpPart : ContentPart
     public IDictionary<string, string> ErrorLogs { get; private set; } = new Dictionary<string, string>();
 
     public void CalculatePercentage() =>
-        ProgressPercentage = (int)Math.Round(((double)ProcessedTenantIds.Count / AllTenantCount * 100)!, 0);
+        ProgressPercentage = (int)Math.Round(((double)ProcessedTenantIds.Count / AllTenantCount * 100)!, 0, MidpointRounding.AwayFromZero);
 
     public bool ShouldPause(string jobId)
     {


### PR DESCRIPTION
[OSOE-1265](https://lombiq.atlassian.net/browse/OSOE-1265)
Fixes MA0193 analyzer warnings introduced by Meziantou.Analyzer 3.0.54 update: add MidpointRounding.AwayFromZero to Math.Round calls in:
- Lombiq.Hosting.Tenants.Maintenance/Models/StaggeredTenantWakeUpPart.cs
- Lombiq.Hosting.Tenants.EmailQuotaManagement/Models/EmailQuota.cs
- Lombiq.Hosting.Tenants.EmailQuotaManagement.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs

[OSOE-1265]: https://lombiq.atlassian.net/browse/OSOE-1265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ