### PR TITLE
OSOE-1311: Remove StringHelper.CreateInvariant usage

### DIFF
--- a/Lombiq.Hosting.Tenants.MediaStorageManagement.Tests.UI/Extensions/MediaStorageManagementExtensions.cs
+++ b/Lombiq.Hosting.Tenants.MediaStorageManagement.Tests.UI/Extensions/MediaStorageManagementExtensions.cs
@@ -1,4 +1,3 @@
-using Lombiq.HelpfulLibraries.Common.Utilities;
 using Lombiq.Tests.UI.Extensions;
 using Lombiq.Tests.UI.Services;
 using Microsoft.Extensions.Logging;
@@ -27,8 +26,8 @@ public static class MediaStorageManagementExtensions
             };
 
         // Exceeding the upload file upload limit causes an error log. This is expected.
-        var permittedErrorMessage = StringHelper.CreateInvariant(
-            $"You tried to upload a file that requires {FileSizeHelpers.FormatAsBytes(maximumStorageQuotaBytes)}");
+        var permittedErrorMessage =
+            $"You tried to upload a file that requires {FileSizeHelpers.FormatAsBytes(maximumStorageQuotaBytes)}";
         configuration.AssertAppLogsAsync = app => app.LogsShouldNotContainAsync(
             logEntry =>
                 logEntry.Level >= LogLevel.Error &&


### PR DESCRIPTION
OSOE-1311.

- Replaced `StringHelper.CreateInvariant` with `string.Create(CultureInfo.InvariantCulture, ...)` since the former doesn't actually apply the invariant culture to interpolation holes; see https://github.com/meziantou/Meziantou.Analyzer/issues/1316#issuecomment-5363658245.
